### PR TITLE
Allow change the installation directory on the install script.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 set -e
 
-curl https://raw.githubusercontent.com/famartinrh/appctl/master/appctl --output $HOME/bin/appctl
-chmod +x $HOME/bin/appctl
+INSTALL_DIR=${INSTALL_DIR:-$HOME/bin}
+
+curl https://raw.githubusercontent.com/famartinrh/appctl/master/appctl --output $INSTALL_DIR/appctl
+chmod +x $INSTALL_DIR/appctl


### PR DESCRIPTION
This change allows configuring the installation directory when executing the install.sh script.

For example : 
curl -sfL https://raw.githubusercontent.com/famartinrh/appctl/set-install-dir/install.sh | INSTALL_DIR=/custom/bin sh -
